### PR TITLE
Death count tracker

### DIFF
--- a/Assets/Scenes/Ivar.unity
+++ b/Assets/Scenes/Ivar.unity
@@ -3989,6 +3989,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1876889858}
   - component: {fileID: 1876889857}
+  - component: {fileID: 1876889859}
   m_Layer: 0
   m_Name: Crypt
   m_TagString: Untagged
@@ -4028,6 +4029,19 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1876889859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1876889856}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e9bd2df9e04659c4f9364d92a6613b9e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  flags: []
 --- !u!1 &1898772527
 GameObject:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Crypts/DeathCountTracker.cs
+++ b/Assets/Scripts/Crypts/DeathCountTracker.cs
@@ -1,0 +1,28 @@
+using DialogueSystem;
+using UnityEngine;
+
+public class DeathCountTracker : MonoBehaviour
+{
+    [SerializeField] private DialogueConditionFlag[] flags;
+
+    private static DeathCountTracker _singleton;
+    private static int deathCount;
+
+    private static bool died = false;
+
+    public void Increment()
+    {
+        if (died)
+            return;
+
+        died = true;
+        if(deathCount < flags.Length)
+            flags[deathCount].Set(true);
+        deathCount++;
+    }
+
+    public void Reenable()
+    {
+        died = false;
+    }
+}

--- a/Assets/Scripts/Crypts/DeathCountTracker.cs.meta
+++ b/Assets/Scripts/Crypts/DeathCountTracker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9bd2df9e04659c4f9364d92a6613b9e

--- a/Assets/Scripts/Dialogue/DialogueEvent.cs
+++ b/Assets/Scripts/Dialogue/DialogueEvent.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 
 namespace DialogueSystem
 {
-    public enum DialogueEventType { Disabled, SetConditionFlag, PlaySound, ShakeCamera, AdvanceTime }
+    public enum DialogueEventType { Disabled, SetConditionFlag, PlaySound, ShakeCamera, AdvanceTime, SetSprite }
 
     [System.Serializable]
     public class DialogueEvent
@@ -21,6 +21,9 @@ namespace DialogueSystem
 
         // camera shake
         public float shakeMagnitude;
+
+        // set sprite
+        public Sprite sprite;
 
 
         public void Invoke(DialoguePlayer player)

--- a/Assets/Scripts/Dialogue/editor/Editor_DIalogueEvent.cs
+++ b/Assets/Scripts/Dialogue/editor/Editor_DIalogueEvent.cs
@@ -37,6 +37,10 @@ public class DialogueEventDrawer : PropertyDrawer
             case DialogueEventType.ShakeCamera:
                 DrawLabeledField(position.x, ref y, "Magnitude", property.FindPropertyRelative("shakeMagnitude"), LabelWidth);
                 break;
+
+            case DialogueEventType.SetSprite:
+                DrawLabeledField(position.x, ref y, "Sprite", property.FindPropertyRelative("sprite"), LabelWidth);
+                break;
         }
 
         EditorGUI.EndProperty();

--- a/Assets/Scripts/GameManagement/PlayerManager.cs
+++ b/Assets/Scripts/GameManagement/PlayerManager.cs
@@ -1,6 +1,7 @@
 using Player;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace GameManagement
 {

--- a/Assets/Scripts/Interactables/PaperSlip.cs
+++ b/Assets/Scripts/Interactables/PaperSlip.cs
@@ -2,12 +2,15 @@ using Player;
 using Player.InventoryManagement;
 using UI;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Interactables
 {
     public class Note : Interactable
     {
         public NoteData note;
+
+        public UnityEvent onInteract;
 
         private void Awake()
         {
@@ -18,6 +21,8 @@ namespace Interactables
             UIManager.SetState<NoteUIState>();
             UIManager.CallUIEvent(new NoteUIEvent() { noteData = note } );
             Destroy(gameObject);
+
+            onInteract.Invoke();
         }
 
         public override void OnUseStart(PlayerController controller) { }


### PR DESCRIPTION
### Summary
Minor changes, the designers needed a deathcounttracker to set what NPCs die per night, set sprite event so the people working on dialogue can set the sprite the character should have, and the note should have an onInteract() event so the designers can enable or disable certain objects when interacting

### Changes
New: DeathCountTracker, sets a condition flag to true at the first time the player dies per night
new: sprite event for dialogue system, allows designers to change the sprite during dialogue
new: note "onInteract" event, gets called when the player interacts with the world

 > [!NOTE]
 > Some of these have not been tested properly, i will wait until assembly tomorrow to see if i run into any bugs, theoretically that should be none of course, but who knows